### PR TITLE
Pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit 
-pandas 
-plotly
+streamlit==1.46.0
+pandas==2.3.0
+plotly==6.1.2


### PR DESCRIPTION
## Summary
- pin package versions in `requirements.txt`
- test installing dependencies

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_685780710980832f8fe43ae4d3008ebc